### PR TITLE
Use dynamic scoring from config for ctftime export

### DIFF
--- a/src/iCTF Website/Controllers/LeaderboardController.cs
+++ b/src/iCTF Website/Controllers/LeaderboardController.cs
@@ -5,6 +5,7 @@ using iCTF_Website.Attributes;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -19,17 +20,20 @@ namespace iCTF_Website.Controllers {
     public class LeaderboardController : Controller {
 
         private readonly DatabaseContext _context;
+        private readonly IConfiguration _configuration;
 
-        public LeaderboardController(DatabaseContext context)
+        public LeaderboardController(DatabaseContext context, IConfiguration configuration)
         {
             _context = context;
+            _configuration = configuration;
         }
 
         [HttpGet("ctftime")]
         [RequireRoles("Administrator")]
         public async Task<IActionResult> CtftimeAsync()
         {
-            var top = await SharedLeaderboardManager.GetTopUsersAndTeams(_context, int.MaxValue);
+            bool dynamicScoring = _configuration.GetValue<bool>("DynamicScoring");
+            var top = await SharedLeaderboardManager.GetTopUsersAndTeams(_context, int.MaxValue, dynamicScoring);
             var teams = new List<dynamic>();
 
             for (int i = 0; i < top.Count; i++)


### PR DESCRIPTION
The ctftime export endpoint does not currently take into account whether dynamic scoring is enabled (instead it defaults to disabled) which can cause confusion when the leaderboard in the json does not match what is shown on the site. 

This change change makes use of the config value set rather than defaulting.