### PR TITLE
Support SMTP Username

### DIFF
--- a/appsettings.json.sample
+++ b/appsettings.json.sample
@@ -14,6 +14,7 @@
     "SmtpDomain": "smtp.gmail.com",
     "SmtpPort": 587,
     "Email": "",
+    "Username": "",
     "Password": ""
   },
 

--- a/src/iCTF Website/Services/EmailService.cs
+++ b/src/iCTF Website/Services/EmailService.cs
@@ -31,7 +31,7 @@ namespace iCTF_Website.Services
 
         public void Send(string to, string subject, string html)
         {
-            var email = getMessage(to, _settings.Email, subject, html);
+            var email = GetMessage(to, _settings.Email, subject, html);
 
             using var smtp = new SmtpClient();
             smtp.Connect(_settings.SmtpDomain, _settings.SmtpPort, SecureSocketOptions.StartTls);
@@ -42,7 +42,7 @@ namespace iCTF_Website.Services
 
         public async Task SendAsync(string to, string subject, string html)
         {
-            var email = getMessage(to, _settings.Email, subject, html);
+            var email = GetMessage(to, _settings.Email, subject, html);
 
             using var smtp = new SmtpClient();
             await smtp.ConnectAsync(_settings.SmtpDomain, _settings.SmtpPort, SecureSocketOptions.StartTls);
@@ -51,7 +51,7 @@ namespace iCTF_Website.Services
             await smtp.DisconnectAsync(true);
         }
 
-        private MimeMessage getMessage(string to, string from, string subject, string html)
+        private MimeMessage GetMessage(string to, string from, string subject, string html)
         {
             // create message
             var email = new MimeMessage();

--- a/src/iCTF Website/Services/EmailService.cs
+++ b/src/iCTF Website/Services/EmailService.cs
@@ -10,64 +10,57 @@ using System.Threading.Tasks;
 
 namespace iCTF_Website.Services
 {
-    public interface IEmailService {
+    public interface IEmailService
+    {
         void Send(string to, string subject, string html);
         Task SendAsync(string to, string subject, string html);
     }
 
-    public class EmailService : IEmailService {
+    public class EmailService : IEmailService
+    {
+        private readonly record struct EmailSettings(string SmtpDomain, int SmtpPort, string Email, string Username, string Password);
 
         private readonly IConfiguration _configuration;
+        private readonly EmailSettings _settings;
 
         public EmailService(IServiceProvider serviceProvider)
         {
             _configuration = serviceProvider.GetService<IConfiguration>();
+            _settings = _configuration.GetSection("EmailSettings").Get<EmailSettings>();
         }
 
         public void Send(string to, string subject, string html)
         {
-            var settings = _configuration.GetSection("EmailSettings");
-            string emailAddress = settings.GetValue<string>("Email");
-            string password = settings.GetValue<string>("Password");
-            string smtpDomain = settings.GetValue<string>("SmtpDomain");
-            int smtpPort = settings.GetValue<int>("SmtpPort");
+            var email = getMessage(to, _settings.Email, subject, html);
 
-            // create message
-            var email = new MimeMessage();
-            email.From.Add(MailboxAddress.Parse(emailAddress));
-            email.To.Add(MailboxAddress.Parse(to));
-            email.Subject = subject;
-            email.Body = new TextPart(TextFormat.Html) { Text = html };
-
-            // send email
             using var smtp = new SmtpClient();
-            smtp.Connect(smtpDomain, smtpPort, SecureSocketOptions.StartTls);
-            smtp.Authenticate(emailAddress, password);
+            smtp.Connect(_settings.SmtpDomain, _settings.SmtpPort, SecureSocketOptions.StartTls);
+            smtp.Authenticate(userName: _settings.Username, password: _settings.Password);
             smtp.Send(email);
             smtp.Disconnect(true);
         }
 
         public async Task SendAsync(string to, string subject, string html)
         {
-            var settings = _configuration.GetSection("EmailSettings");
-            string emailAddress = settings.GetValue<string>("Email");
-            string password = settings.GetValue<string>("Password");
-            string smtpDomain = settings.GetValue<string>("SmtpDomain");
-            int smtpPort = settings.GetValue<int>("SmtpPort");
+            var email = getMessage(to, _settings.Email, subject, html);
 
+            using var smtp = new SmtpClient();
+            await smtp.ConnectAsync(_settings.SmtpDomain, _settings.SmtpPort, SecureSocketOptions.StartTls);
+            await smtp.AuthenticateAsync(userName: _settings.Username, password: _settings.Password);
+            await smtp.SendAsync(email);
+            await smtp.DisconnectAsync(true);
+        }
+
+        private MimeMessage getMessage(string to, string from, string subject, string html)
+        {
             // create message
             var email = new MimeMessage();
-            email.From.Add(MailboxAddress.Parse(emailAddress));
+            email.From.Add(MailboxAddress.Parse(from));
             email.To.Add(MailboxAddress.Parse(to));
             email.Subject = subject;
             email.Body = new TextPart(TextFormat.Html) { Text = html };
 
-            // send email
-            using var smtp = new SmtpClient();
-            await smtp.ConnectAsync(smtpDomain, smtpPort, SecureSocketOptions.StartTls);
-            await smtp.AuthenticateAsync(emailAddress, password);
-            await smtp.SendAsync(email);
-            await smtp.DisconnectAsync(true);
+            return email;
         }
     }
 }


### PR DESCRIPTION
Some smtp relays require the smtp username to be set to a different value to the sending email address, for example sendgrid which takes a username of "apikey" or Amazon SES which uses the access key id.

Some small refactors to EmailService to reduce duplication.